### PR TITLE
 Return a merchant’s invoices with coupon_id if used

### DIFF
--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,4 +1,4 @@
 class InvoiceSerializer
   include JSONAPI::Serializer
-  attributes :merchant_id, :customer_id, :status
+  attributes :merchant_id, :customer_id, :status, :coupon_id
 end


### PR DESCRIPTION
Type of change

  - [x] New feature
  - [ ] Bug Fix

Check the correct boxes

  - [x] This code broke nothing
  - [ ] This code broke some stuff
  - [ ] This code broke everything

Implements/Fixes:

  - This PR adds the coupon_id attribute to the invoice serializer and tests that coupon_id shows up when running the get actions for invoices.

Testing Changes:

  - [x] I have fully tested my code 
  - [x] All tests are passing
  - [ ] Some tests are failing
  - [ ] All tests are failing

  - [ ] No previous tests have been changed
  - [x] Some previous tests have been changed
  - [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)
I added a merchant, customer,  coupon, and a couple of invoices to the existing test data in the invoices_request_spec via the before :each block.

Checklist:

  - [x] I have reviewed my code
  - [ ] The code will run locally
  - [ ] My code has no unused/commented out code
  - [ ] I have commented my code, particularly in hard-to-understand areas

 